### PR TITLE
Fix breaking selector if url has leading dots

### DIFF
--- a/FieldtypeAssistedURL.module
+++ b/FieldtypeAssistedURL.module
@@ -83,7 +83,7 @@ class FieldtypeAssistedURL extends FieldtypeURL
         }
         if(strpos($value, '//') === false) {
             $urlParts = explode("?", $value);
-            $p = $this->wire('pages')->get($urlParts[0]);
+            $p = $this->wire('pages')->get(trim($urlParts[0],'.'));
             if($p->id) {
                 $return = $p->id . (isset($urlParts[1]) ? '?' . $urlParts[1] : '');
             }


### PR DESCRIPTION
a relative url with leading dots (e.g. '../my-url-slug/') breaks the selector to get the page id.
such urls are generated, when the user selects a page from the page tree (in my case inside a repeater)