### PR TITLE
Fix issue with sub-domain + CSS

### DIFF
--- a/FieldtypeAssistedURL.module
+++ b/FieldtypeAssistedURL.module
@@ -75,7 +75,7 @@ class FieldtypeAssistedURL extends FieldtypeURL {
      */
     public function ___sleepValue(Page $page, Field $field, $value) {
         foreach($this->wire('config')->httpHosts as $host) {
-			$temp = preg_replace('#^https?://#', '', $value);
+            $temp = preg_replace('#^https?://#', '', $value);
             if (strpos($temp, $host) === 0) {
                 $value = str_replace($host, '', $value);
                 $value = preg_replace('#^https?://#', '', $value);

--- a/FieldtypeAssistedURL.module
+++ b/FieldtypeAssistedURL.module
@@ -75,7 +75,8 @@ class FieldtypeAssistedURL extends FieldtypeURL {
      */
     public function ___sleepValue(Page $page, Field $field, $value) {
         foreach($this->wire('config')->httpHosts as $host) {
-            if (strpos($value, $host) !== false) {
+			$temp = preg_replace('#^https?://#', '', $value);
+            if (strpos($temp, $host) === 0) {
                 $value = str_replace($host, '', $value);
                 $value = preg_replace('#^https?://#', '', $value);
             }

--- a/InputfieldAssistedURL.css
+++ b/InputfieldAssistedURL.css
@@ -1,9 +1,9 @@
 .InputfieldAssistedURLOpen {
-  float:left;
+    float: left;
+    margin-right: 0 !important;
+    border-radius: 4px 0 0 4px !important;
 }
 
 .InputfieldAssistedUrlText {
-  overflow: hidden;
-  padding-left: 0.8em;
-  padding-top: 0.4em;
+    overflow: hidden;
 }


### PR DESCRIPTION
Hi Adrian,

Earlier I had an issue with the module when saving a url to a sub-domain. The domain was detected as part of the URL and things got messed up. I added a check to make sure the host is at the index 0 of the URL (minus https://).

I also did a quick change to the CSS so it looks like this:

Before
<img width="295" alt="Screenshot 2022-09-05 at 19 11 20" src="https://user-images.githubusercontent.com/6616448/188493690-f9788839-e418-47fd-9efa-970b34f55a87.png">

After
<img width="347" alt="Screenshot 2022-09-05 at 19 10 22" src="https://user-images.githubusercontent.com/6616448/188493693-d1b6b26b-74ec-496d-a927-76c7c92aca9a.png">

Best,
Romain