### PR TITLE
Check for the absence of mailto: before looking for a page

### DIFF
--- a/FieldtypeAssistedURL.module
+++ b/FieldtypeAssistedURL.module
@@ -81,7 +81,7 @@ class FieldtypeAssistedURL extends FieldtypeURL {
                 $value = preg_replace('#^https?://#', '', $value);
             }
         }
-        if(strpos($value, '//') === false) {
+        if(strpos($value, '//') === false && strpos($value, 'mailto:') === false) {
             $urlParts = explode("?", $value);
 
             if($this->wire('config')->urls->root !== '/') {


### PR DESCRIPTION
As the fieldtype, when opening the dialog, suggests and allows the input of an email (and converts it automatically to `mailto:address@domain.tld`), we have to check for the presence of `mailto:` before looking for a page.

This prevents the possibility of a malformed selector (with an unknown field `mailto`) which would make the saving of the field fail.